### PR TITLE
Add form for custom aliases

### DIFF
--- a/config/doctrine/Alias.orm.yml
+++ b/config/doctrine/Alias.orm.yml
@@ -25,6 +25,10 @@ App\Entity\Alias:
       type: boolean
       options:
         default: 0
+    random:
+      type: boolean
+      options:
+        default: 0
   manyToOne:
     user:
       targetEntity: User

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -10,9 +10,9 @@ index:
   voucher-headline: Deine Einladungscodes
   voucher-limit: Du hast keine Einladungscodes mehr verfügbar.
   voucher-disable: Du bekommst am %date% Uhr drei Einladungscodes gutgeschrieben. Dies dient der Vermeidung von Massenregistrierungen und Spam.
-  alias-headline: Deine Aliase
-  alias-limit: Du hast das Limit  von %alias_limit% erlaubten %alias_type% Aliases erreicht. Wenn du alte Aliases löschst, kannst du wieder neue erstellen.
-  alias-empty: Du hast noch keine Aliase definiert.
+  alias-headline: Deine %alias_type% Aliase
+  alias-limit: Du hast das Limit von %alias_limit% erlaubten %alias_type% Aliases erreicht. Wenn du alte Aliases löschst, kannst du wieder neue erstellen.
+  alias-empty: Du hast noch keine %alias_type% Aliase definiert.
   delete-headline: Account löschen
   delete-description: >
     Du kannst deinen Account bei %project_name% löschen. Dadurch werden deine E-Mails unwiderruflich gelöscht. Eine <strong>spätere Wiederherstellung ist nicht möglich.</strong>

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -11,7 +11,7 @@ index:
   voucher-limit: Du hast keine Einladungscodes mehr verfügbar.
   voucher-disable: Du bekommst am %date% Uhr drei Einladungscodes gutgeschrieben. Dies dient der Vermeidung von Massenregistrierungen und Spam.
   alias-headline: Deine Aliase
-  alias-limit: Du hast das Limit  von %alias_limit% erlaubten Aliases erreicht. Wenn du alte Aliases löschst, kannst du wieder neue erstellen.
+  alias-limit: Du hast das Limit  von %alias_limit% erlaubten %alias_type% Aliases erreicht. Wenn du alte Aliases löschst, kannst du wieder neue erstellen.
   alias-empty: Du hast noch keine Aliase definiert.
   delete-headline: Account löschen
   delete-description: >
@@ -125,3 +125,6 @@ error:
 
 # internal translations
 Bad credentials.: Fehlerhafte Zugangsdaten
+
+custom: spezifischen
+random: zufälligen

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -36,12 +36,14 @@ form:
   voucher-redeemed-on: Eingelöst am
   oclock-by: Uhr von
   actual-password: Aktuelles Passwort
+  new-custom-alias: Neues spezifisches Alias
   new-password: Neues Passwort
   new-password_confirmation: Neues Passwort bestätigen
   change-password: Passwort ändern
   delete-account: Account löschen
   delete-password: Passwort
   create-voucher: Erstelle Einladungscode
+  create-custom-alias: Erstelle spezifisches Alias
   create-random-alias: Generiere Zufalls-Alias
   delete-alias: Alias löschen
 
@@ -108,6 +110,7 @@ flashes:
   password-change-successful: Dein neues Passwort ist ab sofort aktiv!
   registration-successful: Du hast dich erfolgreich registriert!
   voucher-creation-successful: Du hast einen neuen Einladungscode erstellt!
+  custom-alias-creation-successful: Dein neues Alias wurde erstellt!
   random-alias-creation-successful: Dir wurde ein neues Zufalls-Alias erstellt!
   alias-deletion-successful: Dein Alias wurde erfolgreich gelöscht!
 

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -36,14 +36,14 @@ form:
   voucher-redeemed-on: Eingelöst am
   oclock-by: Uhr von
   actual-password: Aktuelles Passwort
-  new-custom-alias: Neues spezifische Alias-Adresse
+  new-custom-alias: Neue Alias-Adresse
   new-password: Neues Passwort
   new-password_confirmation: Neues Passwort bestätigen
   change-password: Passwort ändern
   delete-account: Account löschen
   delete-password: Passwort
   create-voucher: Erstelle Einladungscode
-  create-custom-alias: Erstelle spezifische Alias-Adresse
+  create-custom-alias: Erstelle Alias-Adresse
   create-random-alias: Generiere zufällige Alias-Adresse
   delete-alias: Alias-Adresse löschen
 
@@ -125,5 +125,5 @@ error:
 # internal translations
 Bad credentials.: Fehlerhafte Zugangsdaten
 
-custom: spezifischen
+custom: gewählten
 random: zufälligen

--- a/default_translations/de/messages.de.yml
+++ b/default_translations/de/messages.de.yml
@@ -10,9 +10,9 @@ index:
   voucher-headline: Deine Einladungscodes
   voucher-limit: Du hast keine Einladungscodes mehr verfügbar.
   voucher-disable: Du bekommst am %date% Uhr drei Einladungscodes gutgeschrieben. Dies dient der Vermeidung von Massenregistrierungen und Spam.
-  alias-headline: Deine %alias_type% Aliase
-  alias-limit: Du hast das Limit von %alias_limit% erlaubten %alias_type% Aliases erreicht. Wenn du alte Aliases löschst, kannst du wieder neue erstellen.
-  alias-empty: Du hast noch keine %alias_type% Aliase definiert.
+  alias-headline: Deine %alias_type% Alias-Adressen
+  alias-limit: Du hast das Limit von %alias_limit% erlaubten %alias_type% Alias-Adressen erreicht. Wenn du alte Adressen löschst, kannst du wieder neue erstellen.
+  alias-empty: Du hast noch keine %alias_type% Alias-Adressen definiert.
   delete-headline: Account löschen
   delete-description: >
     Du kannst deinen Account bei %project_name% löschen. Dadurch werden deine E-Mails unwiderruflich gelöscht. Eine <strong>spätere Wiederherstellung ist nicht möglich.</strong>
@@ -36,16 +36,16 @@ form:
   voucher-redeemed-on: Eingelöst am
   oclock-by: Uhr von
   actual-password: Aktuelles Passwort
-  new-custom-alias: Neues spezifisches Alias
+  new-custom-alias: Neues spezifische Alias-Adresse
   new-password: Neues Passwort
   new-password_confirmation: Neues Passwort bestätigen
   change-password: Passwort ändern
   delete-account: Account löschen
   delete-password: Passwort
   create-voucher: Erstelle Einladungscode
-  create-custom-alias: Erstelle spezifisches Alias
-  create-random-alias: Generiere Zufalls-Alias
-  delete-alias: Alias löschen
+  create-custom-alias: Erstelle spezifische Alias-Adresse
+  create-random-alias: Generiere zufällige Alias-Adresse
+  delete-alias: Alias-Adresse löschen
 
 navbar_left:
   about-us:
@@ -97,8 +97,8 @@ closed:
 
 delete:
   alias:
-    headline: Alias %alias% löschen
-    lead: Mit der Bestätigung deines Passworts kannst du dein Alias unwiderruflich löschen.
+    headline: Alias-Adresse %alias% löschen
+    lead: Mit der Bestätigung deines Passworts kannst du deine Alias-Adresse unwiderruflich löschen.
   user:
     headline: Account löschen
     lead: Mit der Bestätigung deines Passworts kannst du deinen Account unwiderruflich löschen.
@@ -110,9 +110,8 @@ flashes:
   password-change-successful: Dein neues Passwort ist ab sofort aktiv!
   registration-successful: Du hast dich erfolgreich registriert!
   voucher-creation-successful: Du hast einen neuen Einladungscode erstellt!
-  custom-alias-creation-successful: Dein neues Alias wurde erstellt!
-  random-alias-creation-successful: Dir wurde ein neues Zufalls-Alias erstellt!
-  alias-deletion-successful: Dein Alias wurde erfolgreich gelöscht!
+  alias-creation-successful: Deine neue Alias-Adresse wurde erstellt!
+  alias-deletion-successful: Deine Alias-Adresse wurde erfolgreich gelöscht!
 
 flash_batch_remove_vouchers_success: Nicht eingelöste Vouchers erfolgreich gelöscht
 

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -36,14 +36,14 @@ form:
   voucher-redeemed-on: Redeemed on
   oclock-by: by
   actual-password: Current password
-  new-custom-alias: New custom alias address
+  new-custom-alias: New alias address
   new-password: New password
   new-password_confirmation: Confirm new password
   change-password: Change your password
   delete-account: Delete account
   delete-password: Password
   create-voucher: Create invite code
-  create-custom-alias: Add custom alias address
+  create-custom-alias: Add alias address
   create-random-alias: Generate random alias address
   delete-alias: Delete alias address
 

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -10,9 +10,9 @@ index:
   voucher-headline: Your invite codes
   voucher-limit: You don't have any invite codes left.
   voucher-disable: At %date% you will receive three invite codes. This is to avoid mass registrations and spam.
-  alias-headline: Your aliases
+  alias-headline: Your %alias_type% aliases
   alias-limit: You reached the allowed limit of %alias_limit% %alias_type% aliases. As soon as you delete old aliases, you can create new ones again.
-  alias-empty: You don't have any aliases defined.
+  alias-empty: You don't have any %alias_type% aliases defined.
   delete-headline: Delete account
   delete-description: >
     You can delete your %project_name% email account. This will delete all your emails. <strong>A recovery at a later date is not possible.</strong>

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -36,12 +36,14 @@ form:
   voucher-redeemed-on: Redeemed on
   oclock-by: by
   actual-password: Current password
+  new-custom-alias: New custom alias
   new-password: New password
   new-password_confirmation: Confirm new password
   change-password: Change your password
   delete-account: Delete account
   delete-password: Password
   create-voucher: Create invite code
+  create-custom-alias: Add custom alias
   create-random-alias: Generate random alias
   delete-alias: Delete alias
 
@@ -108,6 +110,7 @@ flashes:
   password-change-successful: Your new password is now active!
   registration-successful: You have been successfully registered!
   voucher-creation-successful: You created a new invite code!
+  custom-alias-creation-successful: Your new alias was created!
   random-alias-creation-successful: You got a new random alias created!
   alias-deletion-successful: Your alias successfully got deleted!
 

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -10,9 +10,9 @@ index:
   voucher-headline: Your invite codes
   voucher-limit: You don't have any invite codes left.
   voucher-disable: At %date% you will receive three invite codes. This is to avoid mass registrations and spam.
-  alias-headline: Your %alias_type% aliases
-  alias-limit: You reached the allowed limit of %alias_limit% %alias_type% aliases. As soon as you delete old aliases, you can create new ones again.
-  alias-empty: You don't have any %alias_type% aliases defined.
+  alias-headline: Your %alias_type% alias addresses
+  alias-limit: You reached the allowed limit of %alias_limit% %alias_type% alias addresses. As soon as you delete old addresses, you can create new ones again.
+  alias-empty: You don't have any %alias_type% alias addresses defined.
   delete-headline: Delete account
   delete-description: >
     You can delete your %project_name% email account. This will delete all your emails. <strong>A recovery at a later date is not possible.</strong>
@@ -36,16 +36,16 @@ form:
   voucher-redeemed-on: Redeemed on
   oclock-by: by
   actual-password: Current password
-  new-custom-alias: New custom alias
+  new-custom-alias: New custom alias address
   new-password: New password
   new-password_confirmation: Confirm new password
   change-password: Change your password
   delete-account: Delete account
   delete-password: Password
   create-voucher: Create invite code
-  create-custom-alias: Add custom alias
-  create-random-alias: Generate random alias
-  delete-alias: Delete alias
+  create-custom-alias: Add custom alias address
+  create-random-alias: Generate random alias address
+  delete-alias: Delete alias address
 
 navbar_left:
   about-us:
@@ -97,8 +97,8 @@ closed:
 
 delete:
   alias:
-    headline: Delete alias %alias%
-    lead: We need to verify your password to delete your alias.
+    headline: Delete alias address %alias%
+    lead: We need to verify your password to delete your alias address.
   user:
     headline: Delete account
     lead: We need to verify your password to delete your account.
@@ -110,9 +110,8 @@ flashes:
   password-change-successful: Your new password is now active!
   registration-successful: You have been successfully registered!
   voucher-creation-successful: You created a new invite code!
-  custom-alias-creation-successful: Your new alias was created!
-  random-alias-creation-successful: You got a new random alias created!
-  alias-deletion-successful: Your alias successfully got deleted!
+  alias-creation-successful: Your new alias address was created!
+  alias-deletion-successful: Your alias address was successfully deleted!
 
 flash_batch_remove_vouchers_success: Successfully deleted unredeemed vouchers
 

--- a/default_translations/en/messages.en.yml
+++ b/default_translations/en/messages.en.yml
@@ -11,7 +11,7 @@ index:
   voucher-limit: You don't have any invite codes left.
   voucher-disable: At %date% you will receive three invite codes. This is to avoid mass registrations and spam.
   alias-headline: Your aliases
-  alias-limit: You reached the allowed limit of %alias_limit% aliases. As soon as you delete old aliases, you can create new ones again.
+  alias-limit: You reached the allowed limit of %alias_limit% %alias_type% aliases. As soon as you delete old aliases, you can create new ones again.
   alias-empty: You don't have any aliases defined.
   delete-headline: Delete account
   delete-description: >
@@ -125,3 +125,6 @@ error:
 
 # internal translations
 Bad credentials.: Wrong login details
+
+custom: custom
+random: random

--- a/features/user.feature
+++ b/features/user.feature
@@ -40,6 +40,18 @@ Feature: User
     And I should see text matching "You got a new random alias created!"
     And the response status code should be 200
 
+  @create-custom-alias
+  Scenario: Create custom alias
+    When I am authenticated as "user@example.org"
+    And I am on "/"
+    And I fill in the following:
+      | alias | test_alias |
+    And I press "Add custom alias"
+
+    Then I should be on "/"
+    And I should see text matching " Your new alias was created!"
+    And the response status code should be 200
+
   @delete-alias
   Scenario: Delete alias
     When I am authenticated as "user@example.org"

--- a/features/user.feature
+++ b/features/user.feature
@@ -46,7 +46,7 @@ Feature: User
     And I am on "/"
     And I fill in the following:
       | alias | test_alias |
-    And I press "Add custom alias"
+    And I press "Add alias address"
 
     Then I should be on "/"
     And I should see text matching "Your new alias address was created!"

--- a/features/user.feature
+++ b/features/user.feature
@@ -37,7 +37,7 @@ Feature: User
     And I press "Generate random alias"
 
     Then I should be on "/"
-    And I should see text matching "You got a new random alias created!"
+    And I should see text matching "Your new alias address was created!"
     And the response status code should be 200
 
   @create-custom-alias
@@ -49,7 +49,7 @@ Feature: User
     And I press "Add custom alias"
 
     Then I should be on "/"
-    And I should see text matching " Your new alias was created!"
+    And I should see text matching "Your new alias address was created!"
     And the response status code should be 200
 
   @delete-alias
@@ -61,7 +61,7 @@ Feature: User
     And I press "Delete alias"
 
     Then I should be on "/"
-    And I should see text matching "Your alias successfully got deleted!"
+    And I should see text matching "Your alias address was successfully deleted!"
     And the response status code should not be 403
 
   @delete-alias

--- a/src/Controller/StartController.php
+++ b/src/Controller/StartController.php
@@ -175,7 +175,7 @@ class StartController extends Controller
     {
         try {
             if ($this->aliasHandler->create($user) instanceof Alias) {
-                $request->getSession()->getFlashBag()->add('success', 'flashes.random-alias-creation-successful');
+                $request->getSession()->getFlashBag()->add('success', 'flashes.alias-creation-successful');
             }
         } catch (ValidationException $e) {
             $request->getSession()->getFlashBag()->add('error', $e->getMessage());
@@ -191,7 +191,7 @@ class StartController extends Controller
     {
         try {
             if ($this->aliasHandler->create($user, $alias) instanceof Alias) {
-                $request->getSession()->getFlashBag()->add('success', 'flashes.custom-alias-creation-successful');
+                $request->getSession()->getFlashBag()->add('success', 'flashes.alias-creation-successful');
             }
         } catch (ValidationException $e) {
             $request->getSession()->getFlashBag()->add('error', $e->getMessage());

--- a/src/Controller/StartController.php
+++ b/src/Controller/StartController.php
@@ -9,6 +9,7 @@ use App\Exception\ValidationException;
 use App\Form\Model\AliasCreate;
 use App\Form\Model\PasswordChange;
 use App\Form\Model\VoucherCreate;
+use App\Form\CustomAliasCreateType;
 use App\Form\RandomAliasCreateType;
 use App\Form\PasswordChangeType;
 use App\Form\VoucherCreateType;
@@ -89,6 +90,16 @@ class StartController extends Controller
             ]
         );
 
+        $aliasCreate = new AliasCreate();
+        $customAliasCreateForm = $this->createForm(
+            CustomAliasCreateType::class,
+            $aliasCreate,
+            [
+                'action' => $this->generateUrl('index'),
+                'method' => 'post',
+            ]
+        );
+
         $passwordChange = new PasswordChange();
         $passwordChangeForm = $this->createForm(
             PasswordChangeType::class,
@@ -102,12 +113,15 @@ class StartController extends Controller
         if ('POST' === $request->getMethod()) {
             $voucherCreateForm->handleRequest($request);
             $randomAliasCreateForm->handleRequest($request);
+            $customAliasCreateForm->handleRequest($request);
             $passwordChangeForm->handleRequest($request);
 
             if ($voucherCreateForm->isSubmitted() && $voucherCreateForm->isValid()) {
                 $this->createVoucher($request, $user);
             } elseif ($randomAliasCreateForm->isSubmitted() && $randomAliasCreateForm->isValid()) {
                 $this->createRandomAlias($request, $user);
+            } elseif ($customAliasCreateForm->isSubmitted() && $customAliasCreateForm->isValid()) {
+                $this->createCustomAlias($request, $user, $aliasCreate->alias);
             } elseif ($passwordChangeForm->isSubmitted() && $passwordChangeForm->isValid()) {
                 $this->changePassword($request, $user, $passwordChange->newPassword);
             }
@@ -126,6 +140,7 @@ class StartController extends Controller
                 'vouchers' => $vouchers,
                 'voucher_form' => $voucherCreateForm->createView(),
                 'random_alias_form' => $randomAliasCreateForm->createView(),
+                'custom_alias_form' => $customAliasCreateForm->createView(),
                 'password_form' => $passwordChangeForm->createView(),
             ]
         );
@@ -160,6 +175,22 @@ class StartController extends Controller
             }
         } catch (ValidationException $e) {
             // Should not thrown
+        }
+    }
+
+    /**
+     * @param Request $request
+     * @param User    $user
+     * @param string  $alias
+     */
+    private function createCustomAlias(Request $request, User $user, string $alias)
+    {
+        try {
+            if ($this->aliasHandler->create($user, $alias) instanceof Alias) {
+                $request->getSession()->getFlashBag()->add('success', 'flashes.custom-alias-creation-successful');
+            }
+        } catch (ValidationException $e) {
+            $request->getSession()->getFlashBag()->add('error', $e->getMessage());
         }
     }
 

--- a/src/Controller/StartController.php
+++ b/src/Controller/StartController.php
@@ -128,7 +128,6 @@ class StartController extends Controller
         }
 
         $aliasRepository = $this->get('doctrine')->getRepository('App:Alias');
-        $aliases = $aliasRepository->findByUser($user);
         $aliasesRandom = $aliasRepository->findByUser($user, true);
         $aliasesCustom = $aliasRepository->findByUser($user, false);
         $vouchers = $this->voucherHandler->getVouchersByUser($user);
@@ -137,9 +136,11 @@ class StartController extends Controller
             'Start/index.html.twig',
             [
                 'user' => $user,
+                'user_domain' => $user->getDomain(),
                 'alias_creation_random' => $this->aliasHandler->checkAliasLimit($aliasesRandom, true),
                 'alias_creation_custom' => $this->aliasHandler->checkAliasLimit($aliasesCustom),
-                'aliases' => $aliases,
+                'aliases_custom' => $aliasesCustom,
+                'aliases_random' => $aliasesRandom,
                 'vouchers' => $vouchers,
                 'voucher_form' => $voucherCreateForm->createView(),
                 'random_alias_form' => $randomAliasCreateForm->createView(),
@@ -189,7 +190,7 @@ class StartController extends Controller
     private function createCustomAlias(Request $request, User $user, string $alias)
     {
         try {
-            if ($this->aliasHandler->create($user, strtolower($alias)) instanceof Alias) {
+            if ($this->aliasHandler->create($user, $alias) instanceof Alias) {
                 $request->getSession()->getFlashBag()->add('success', 'flashes.custom-alias-creation-successful');
             }
         } catch (ValidationException $e) {

--- a/src/Controller/StartController.php
+++ b/src/Controller/StartController.php
@@ -129,13 +129,16 @@ class StartController extends Controller
 
         $aliasRepository = $this->get('doctrine')->getRepository('App:Alias');
         $aliases = $aliasRepository->findByUser($user);
+        $aliasesRandom = $aliasRepository->findRandomByUser($user);
+        $aliasesCustom = $aliasRepository->findCustomByUser($user);
         $vouchers = $this->voucherHandler->getVouchersByUser($user);
 
         return $this->render(
             'Start/index.html.twig',
             [
                 'user' => $user,
-                'alias_creation' => $this->aliasHandler->checkAliasLimit($aliases),
+                'alias_creation_random' => $this->aliasHandler->checkAliasLimit($aliasesRandom, $this->aliasHandler::ALIAS_LIMIT_RANDOM),
+                'alias_creation_custom' => $this->aliasHandler->checkAliasLimit($aliasesCustom, $this->aliasHandler::ALIAS_LIMIT_CUSTOM),
                 'aliases' => $aliases,
                 'vouchers' => $vouchers,
                 'voucher_form' => $voucherCreateForm->createView(),
@@ -170,7 +173,7 @@ class StartController extends Controller
     private function createRandomAlias(Request $request, User $user)
     {
         try {
-            if ($this->aliasHandler->create($user, null) instanceof Alias) {
+            if ($this->aliasHandler->createRandom($user) instanceof Alias) {
                 $request->getSession()->getFlashBag()->add('success', 'flashes.random-alias-creation-successful');
             }
         } catch (ValidationException $e) {
@@ -186,7 +189,7 @@ class StartController extends Controller
     private function createCustomAlias(Request $request, User $user, string $alias)
     {
         try {
-            if ($this->aliasHandler->create($user, $alias) instanceof Alias) {
+            if ($this->aliasHandler->createCustom($user, $alias) instanceof Alias) {
                 $request->getSession()->getFlashBag()->add('success', 'flashes.custom-alias-creation-successful');
             }
         } catch (ValidationException $e) {

--- a/src/Creator/AliasCreator.php
+++ b/src/Creator/AliasCreator.php
@@ -22,6 +22,7 @@ class AliasCreator extends AbstractCreator
      */
     public function create(User $user, ?string $localPart): Alias
     {
+        $localPart = (isset($localPart)) ? strtolower($localPart) : null;
         $alias = AliasFactory::create($user, $localPart);
 
         if (null === $localPart) {

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -27,11 +27,22 @@ class Alias implements SoftDeletableInterface
     protected $destination;
 
     /**
+     * @var boolean
+     */
+    protected $random;
+
+    /**
+     * @var int
+     */
+    protected $type;
+
+    /**
      * Alias constructor.
      */
     public function __construct()
     {
         $this->deleted = false;
+        $this->random = false;
     }
 
     /**
@@ -69,5 +80,20 @@ class Alias implements SoftDeletableInterface
     public function setEmptyUser()
     {
         $this->user = null;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function isRandom()
+    {
+        return $this->random;
+    }
+
+    public function setRandom()
+    {
+        $this->random = true;
     }
 }

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -6,6 +6,7 @@ use App\Traits\CreationTimeTrait;
 use App\Traits\DeleteTrait;
 use App\Traits\DomainAwareTrait;
 use App\Traits\IdTrait;
+use App\Traits\RandomTrait;
 use App\Traits\UpdatedTimeTrait;
 use App\Traits\UserAwareTrait;
 
@@ -14,7 +15,7 @@ use App\Traits\UserAwareTrait;
  */
 class Alias implements SoftDeletableInterface
 {
-    use IdTrait, CreationTimeTrait, UpdatedTimeTrait, DeleteTrait, DomainAwareTrait, UserAwareTrait;
+    use IdTrait, CreationTimeTrait, UpdatedTimeTrait, DeleteTrait, DomainAwareTrait, UserAwareTrait, RandomTrait;
 
     /**
      * @var string
@@ -25,11 +26,6 @@ class Alias implements SoftDeletableInterface
      * @var string
      */
     protected $destination;
-
-    /**
-     * @var bool
-     */
-    protected $random;
 
     /**
      * Alias constructor.
@@ -75,15 +71,5 @@ class Alias implements SoftDeletableInterface
     public function setEmptyUser()
     {
         $this->user = null;
-    }
-
-    public function isRandom()
-    {
-        return $this->random;
-    }
-
-    public function setRandom()
-    {
-        $this->random = true;
     }
 }

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -32,11 +32,6 @@ class Alias implements SoftDeletableInterface
     protected $random;
 
     /**
-     * @var int
-     */
-    protected $type;
-
-    /**
      * Alias constructor.
      */
     public function __construct()
@@ -80,11 +75,6 @@ class Alias implements SoftDeletableInterface
     public function setEmptyUser()
     {
         $this->user = null;
-    }
-
-    public function getType()
-    {
-        return $this->type;
     }
 
     public function isRandom()

--- a/src/Entity/Alias.php
+++ b/src/Entity/Alias.php
@@ -27,7 +27,7 @@ class Alias implements SoftDeletableInterface
     protected $destination;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $random;
 

--- a/src/Factory/AliasFactory.php
+++ b/src/Factory/AliasFactory.php
@@ -11,6 +11,8 @@ use App\Helper\RandomStringGenerator;
  */
 class AliasFactory
 {
+    const RANDOM_ALIAS_LENGTH = 24;
+
     /**
      * @param User        $user
      * @param null|string $localPart
@@ -25,10 +27,11 @@ class AliasFactory
         $alias->setDomain($domain);
         $alias->setDestination($user->getEmail());
         if (null === $localPart) {
-            $localPart = RandomStringGenerator::generate(24, false);
+            $localPart = RandomStringGenerator::generate(self::RANDOM_ALIAS_LENGTH, false);
+            $alias->setRandom();
         }
 
-        $alias->setSource($localPart.'@'.$domain->getName());
+        $alias->setSource(strtolower($localPart)."@".$domain->getName());
 
         return $alias;
     }

--- a/src/Factory/AliasFactory.php
+++ b/src/Factory/AliasFactory.php
@@ -28,7 +28,7 @@ class AliasFactory
         $alias->setDestination($user->getEmail());
         if (null === $localPart) {
             $localPart = RandomStringGenerator::generate(self::RANDOM_ALIAS_LENGTH, false);
-            $alias->setRandom();
+            $alias->setRandom(true);
         }
 
         $alias->setSource($localPart.'@'.$domain->getName());

--- a/src/Factory/AliasFactory.php
+++ b/src/Factory/AliasFactory.php
@@ -31,7 +31,7 @@ class AliasFactory
             $alias->setRandom();
         }
 
-        $alias->setSource(strtolower($localPart)."@".$domain->getName());
+        $alias->setSource(strtolower($localPart).'@'.$domain->getName());
 
         return $alias;
     }

--- a/src/Factory/AliasFactory.php
+++ b/src/Factory/AliasFactory.php
@@ -31,7 +31,7 @@ class AliasFactory
             $alias->setRandom();
         }
 
-        $alias->setSource(strtolower($localPart).'@'.$domain->getName());
+        $alias->setSource($localPart.'@'.$domain->getName());
 
         return $alias;
     }

--- a/src/Form/CustomAliasCreateType.php
+++ b/src/Form/CustomAliasCreateType.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author tim <tim@systemli.org>
+ */
+class CustomAliasCreateType extends AbstractType
+{
+    const NAME = 'create_custom_alias';
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('alias', TextType::class, array('label' => 'form.new-custom-alias'))
+            ->add('submit', SubmitType::class, array('label' => 'form.create-custom-alias'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(['data_class' => 'App\Form\Model\AliasCreate']);
+    }
+
+    /**
+     * @return string
+     */
+    public function getBlockPrefix()
+    {
+        return self::NAME;
+    }
+}

--- a/src/Handler/AliasHandler.php
+++ b/src/Handler/AliasHandler.php
@@ -61,16 +61,10 @@ class AliasHandler
      */
     public function create(User $user, ?string $localPart = null): ?Alias
     {
-        if (isset($localPart)) {
-            $random = false;
-            $limit = self::ALIAS_LIMIT_CUSTOM;
-        } else {
-            $random = true;
-            $limit = self::ALIAS_LIMIT_RANDOM;
-        }
+        $random = (isset($localPart)) ? false : true;
 
         $aliases = $this->repository->findByUser($user, $random);
-        if ($this->checkAliasLimit($aliases, $limit)) {
+        if ($this->checkAliasLimit($aliases, $random)) {
             return $this->creator->create($user, $localPart);
         }
 

--- a/src/Handler/AliasHandler.php
+++ b/src/Handler/AliasHandler.php
@@ -14,7 +14,8 @@ use Doctrine\Common\Persistence\ObjectManager;
  */
 class AliasHandler
 {
-    const ALIAS_LIMIT = 20;
+    const ALIAS_LIMIT_CUSTOM = 10;
+    const ALIAS_LIMIT_RANDOM = 100;
 
     /**
      * @var AliasRepository
@@ -39,26 +40,40 @@ class AliasHandler
 
     /**
      * @param array $aliases
-     *
+     * @param int $limit
      * @return bool
      */
-    public function checkAliasLimit(array $aliases): bool
+    public function checkAliasLimit(array $aliases, int $limit = self::ALIAS_LIMIT_CUSTOM): bool
     {
-        return (count($aliases) < self::ALIAS_LIMIT) ? true : false;
+        return (count($aliases) < $limit) ? true : false;
     }
 
     /**
-     * @param User        $user
-     * @param null|string $localPart
-     *
+     * @param User $user
      * @return Alias|null
      *
      * @throws ValidationException
      */
-    public function create(User $user, ?string $localPart): ?Alias
+    public function createRandom(User $user): ?Alias
     {
-        $aliases = $this->repository->findByUser($user);
-        if ($this->checkAliasLimit($aliases)) {
+        $aliases = $this->repository->findRandomByUser($user);
+        if ($this->checkAliasLimit($aliases, self::ALIAS_LIMIT_RANDOM)) {
+            return $this->creator->create($user, null);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param User $user
+     * @param string $localPart
+     * @return Alias|null
+     * @throws ValidationException
+     */
+    public function createCustom(User $user, string $localPart): ?Alias
+    {
+        $aliases = $this->repository->findCustomByUser($user);
+        if ($this->checkAliasLimit($aliases, self::ALIAS_LIMIT_CUSTOM)) {
             return $this->creator->create($user, $localPart);
         }
 

--- a/src/Handler/AliasHandler.php
+++ b/src/Handler/AliasHandler.php
@@ -40,44 +40,37 @@ class AliasHandler
 
     /**
      * @param array $aliases
-     * @param int   $limit
+     * @param bool  $random
      *
      * @return bool
      */
-    public function checkAliasLimit(array $aliases, int $limit = self::ALIAS_LIMIT_CUSTOM): bool
+    public function checkAliasLimit(array $aliases, bool $random = false): bool
     {
+        $limit = ($random) ? self::ALIAS_LIMIT_RANDOM : self::ALIAS_LIMIT_CUSTOM;
+
         return (count($aliases) < $limit) ? true : false;
     }
 
     /**
-     * @param User $user
+     * @param User        $user
+     * @param null|string $localPart
      *
      * @return Alias|null
      *
      * @throws ValidationException
      */
-    public function createRandom(User $user): ?Alias
+    public function create(User $user, ?string $localPart = null): ?Alias
     {
-        $aliases = $this->repository->findRandomByUser($user);
-        if ($this->checkAliasLimit($aliases, self::ALIAS_LIMIT_RANDOM)) {
-            return $this->creator->create($user, null);
+        if (isset($localPart)) {
+            $random = false;
+            $limit = self::ALIAS_LIMIT_CUSTOM;
+        } else {
+            $random = true;
+            $limit = self::ALIAS_LIMIT_RANDOM;
         }
 
-        return null;
-    }
-
-    /**
-     * @param User   $user
-     * @param string $localPart
-     *
-     * @return Alias|null
-     *
-     * @throws ValidationException
-     */
-    public function createCustom(User $user, string $localPart): ?Alias
-    {
-        $aliases = $this->repository->findCustomByUser($user);
-        if ($this->checkAliasLimit($aliases, self::ALIAS_LIMIT_CUSTOM)) {
+        $aliases = $this->repository->findByUser($user, $random);
+        if ($this->checkAliasLimit($aliases, $limit)) {
             return $this->creator->create($user, $localPart);
         }
 

--- a/src/Handler/AliasHandler.php
+++ b/src/Handler/AliasHandler.php
@@ -40,7 +40,8 @@ class AliasHandler
 
     /**
      * @param array $aliases
-     * @param int $limit
+     * @param int   $limit
+     *
      * @return bool
      */
     public function checkAliasLimit(array $aliases, int $limit = self::ALIAS_LIMIT_CUSTOM): bool
@@ -50,6 +51,7 @@ class AliasHandler
 
     /**
      * @param User $user
+     *
      * @return Alias|null
      *
      * @throws ValidationException
@@ -65,9 +67,11 @@ class AliasHandler
     }
 
     /**
-     * @param User $user
+     * @param User   $user
      * @param string $localPart
+     *
      * @return Alias|null
+     *
      * @throws ValidationException
      */
     public function createCustom(User $user, string $localPart): ?Alias

--- a/src/Repository/AliasRepository.php
+++ b/src/Repository/AliasRepository.php
@@ -39,4 +39,14 @@ class AliasRepository extends AbstractRepository
     {
         return $this->findBy(['user' => $user]);
     }
+
+    public function findRandomByUser(User $user)
+    {
+        return $this->findBy(['user' => $user, 'random' => true]);
+    }
+
+    public function findCustomByUser(User $user)
+    {
+        return $this->findBy(['user' => $user, 'random' => false]);
+    }
 }

--- a/src/Repository/AliasRepository.php
+++ b/src/Repository/AliasRepository.php
@@ -31,22 +31,17 @@ class AliasRepository extends AbstractRepository
     }
 
     /**
-     * @param User $user
+     * @param User      $user
+     * @param null|bool $random
      *
      * @return array|Alias[]
      */
-    public function findByUser(User $user)
+    public function findByUser(User $user, ?bool $random = null)
     {
-        return $this->findBy(['user' => $user]);
-    }
-
-    public function findRandomByUser(User $user)
-    {
-        return $this->findBy(['user' => $user, 'random' => true]);
-    }
-
-    public function findCustomByUser(User $user)
-    {
-        return $this->findBy(['user' => $user, 'random' => false]);
+        if (isset($random)) {
+            return $this->findBy(['user' => $user, 'random' => $random]);
+        } else {
+            return $this->findBy(['user' => $user]);
+        }
     }
 }

--- a/src/Traits/RandomTrait.php
+++ b/src/Traits/RandomTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Traits;
+
+/**
+ * @author tim <tim@systemli.org>
+ */
+trait RandomTrait
+{
+    /**
+     * @var bool;
+     */
+    private $random;
+
+    /**
+     * @return bool
+     */
+    public function isRandom(): bool
+    {
+        return (bool) $this->random;
+    }
+
+    /**
+     * @param bool $random
+     */
+    public function setRandom($random)
+    {
+        $this->random = $random;
+    }
+}

--- a/templates/Start/aliases.html.twig
+++ b/templates/Start/aliases.html.twig
@@ -25,3 +25,17 @@
 {% else %}
     <p class="alert alert-info">{{ "index.alias-empty"|trans() }}</p>
 {% endif %}
+
+{%  if alias_creation %}
+    {{ form_start(custom_alias_form) }}
+    {{ form_errors(custom_alias_form) }}
+<div class="form-group">
+    {{ form_label(custom_alias_form.alias) }}
+    {{ form_widget(custom_alias_form.alias, {'attr': {'class': 'form-control' }}) }}
+</div>
+
+<div class="form-group">
+    {{ form_widget(custom_alias_form.submit, {'attr': {'class': 'btn btn-primary' } }) }}
+</div>
+{{ form_end(custom_alias_form) }}
+{% endif %}

--- a/templates/Start/aliases.html.twig
+++ b/templates/Start/aliases.html.twig
@@ -1,4 +1,43 @@
-<h3>{{ "index.alias-headline"|trans }}</h3>
+<h3>{{ "index.alias-headline"|trans({'%alias_type%': 'custom'|trans}) }}</h3>
+
+{%  if alias_creation_custom %}
+    {{ form_start(custom_alias_form) }}
+    {{ form_errors(custom_alias_form) }}
+    <div class="form-group">
+        {{ form_label(custom_alias_form.alias) }}
+        <div class="input-group">
+            {{ form_widget(custom_alias_form.alias, {'attr': {'class': 'form-control' }, 'value': ''}) }}
+            <span class="input-group-addon">@{{ user_domain }}</span>
+        </div>
+    </div>
+
+    <div class="form-group">
+        {{ form_widget(custom_alias_form.submit, {'attr': {'class': 'btn btn-primary' } }) }}
+    </div>
+    {{ form_end(custom_alias_form) }}
+{% else %}
+    <p class="alert alert-info">{{ "index.alias-limit"|trans({
+            '%alias_limit%': constant('App\\Handler\\AliasHandler::ALIAS_LIMIT_CUSTOM'),
+            '%alias_type%': 'custom'|trans
+        }) }}</p>
+{% endif %}
+
+{% if aliases_custom is defined and aliases_custom|length > 0 %}
+    <ul class="list-group">
+        {% for alias in aliases_custom %}
+            <li class="list-group-item list-group-item-primary">
+                {{ alias.source }}
+                <span class="pull-right">
+                    <a class="btn btn-danger btn-xs" href="{{ url('alias_delete', {'aliasId': alias.id}) }}">x</a>
+                </span>
+            </li>
+        {% endfor %}
+    </ul>
+{% else %}
+    <p class="alert alert-info">{{ "index.alias-empty"|trans({'%alias_type%': 'custom'|trans}) }}</p>
+{% endif %}
+
+<h3>{{ "index.alias-headline"|trans({'%alias_type%': 'random'|trans}) }}</h3>
 
 {%  if alias_creation_random %}
     {{ form_start(random_alias_form) }}
@@ -14,9 +53,9 @@
         }) }}</p>
 {% endif %}
 
-{% if aliases is defined and aliases|length > 0 %}
+{% if aliases_random is defined and aliases_random|length > 0 %}
     <ul class="list-group">
-        {% for alias in aliases %}
+        {% for alias in aliases_random %}
             <li class="list-group-item list-group-item-primary">
                 {{ alias.source }}
                 <span class="pull-right">
@@ -26,24 +65,6 @@
         {% endfor %}
     </ul>
 {% else %}
-    <p class="alert alert-info">{{ "index.alias-empty"|trans() }}</p>
+    <p class="alert alert-info">{{ "index.alias-empty"|trans({'%alias_type%': 'random'|trans}) }}</p>
 {% endif %}
 
-{%  if alias_creation_custom %}
-    {{ form_start(custom_alias_form) }}
-    {{ form_errors(custom_alias_form) }}
-<div class="form-group">
-    {{ form_label(custom_alias_form.alias) }}
-    {{ form_widget(custom_alias_form.alias, {'attr': {'class': 'form-control' }}) }}
-</div>
-
-<div class="form-group">
-    {{ form_widget(custom_alias_form.submit, {'attr': {'class': 'btn btn-primary' } }) }}
-</div>
-{{ form_end(custom_alias_form) }}
-{% else %}
-    <p class="alert alert-info">{{ "index.alias-limit"|trans({
-            '%alias_limit%': constant('App\\Handler\\AliasHandler::ALIAS_LIMIT_CUSTOM'),
-            '%alias_type%': 'custom'|trans
-        }) }}</p>
-{% endif %}

--- a/templates/Start/aliases.html.twig
+++ b/templates/Start/aliases.html.twig
@@ -10,7 +10,7 @@
 {% else %}
     <p class="alert alert-info">{{ "index.alias-limit"|trans({
             '%alias_limit%': constant('App\\Handler\\AliasHandler::ALIAS_LIMIT_RANDOM'),
-            '%alias_type': random|trans
+            '%alias_type%': random|trans
         }) }}</p>
 {% endif %}
 

--- a/templates/Start/aliases.html.twig
+++ b/templates/Start/aliases.html.twig
@@ -1,6 +1,6 @@
 <h3>{{ "index.alias-headline"|trans }}</h3>
 
-{%  if alias_creation %}
+{%  if alias_creation_random %}
     {{ form_start(random_alias_form) }}
     {{ form_errors(random_alias_form) }}
     <div class="form-group">
@@ -8,7 +8,10 @@
     </div>
     {{ form_end(random_alias_form) }}
 {% else %}
-    <p class="alert alert-info">{{ "index.alias-limit"|trans({'%alias_limit%': constant('App\\Handler\\AliasHandler::ALIAS_LIMIT')}) }}</p>
+    <p class="alert alert-info">{{ "index.alias-limit"|trans({
+            '%alias_limit%': constant('App\\Handler\\AliasHandler::ALIAS_LIMIT_RANDOM'),
+            '%alias_type': random|trans
+        }) }}</p>
 {% endif %}
 
 {% if aliases is defined and aliases|length > 0 %}
@@ -26,7 +29,7 @@
     <p class="alert alert-info">{{ "index.alias-empty"|trans() }}</p>
 {% endif %}
 
-{%  if alias_creation %}
+{%  if alias_creation_custom %}
     {{ form_start(custom_alias_form) }}
     {{ form_errors(custom_alias_form) }}
 <div class="form-group">
@@ -38,4 +41,9 @@
     {{ form_widget(custom_alias_form.submit, {'attr': {'class': 'btn btn-primary' } }) }}
 </div>
 {{ form_end(custom_alias_form) }}
+{% else %}
+    <p class="alert alert-info">{{ "index.alias-limit"|trans({
+            '%alias_limit%': constant('App\\Handler\\AliasHandler::ALIAS_LIMIT_CUSTOM'),
+            '%alias_type%': 'custom'|trans
+        }) }}</p>
 {% endif %}

--- a/tests/Handler/AliasHandlerTest.php
+++ b/tests/Handler/AliasHandlerTest.php
@@ -15,7 +15,7 @@ class AliasHandlerTest extends TestCase
     private function createHandler(array $list)
     {
         $repository = $this->getMockBuilder(AliasRepository::class)->disableOriginalConstructor()->getMock();
-        $repository->expects($this->any())->method('findRandomByUser')->willReturn($list);
+        $repository->expects($this->any())->method('findByUser')->willReturn($list);
 
         $manager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
         $manager->expects($this->any())->method('getRepository')->willReturn($repository);
@@ -39,7 +39,7 @@ class AliasHandlerTest extends TestCase
         $handler = $this->createHandler([]);
         $user = new User();
 
-        self::assertInstanceOf(Alias::class, $handler->createRandom($user));
+        self::assertInstanceOf(Alias::class, $handler->create($user, null));
     }
 
     public function testCreateLimit()
@@ -51,6 +51,6 @@ class AliasHandlerTest extends TestCase
         $handler = $this->createHandler($list);
         $user = new User();
 
-        self::assertNull($handler->createRandom($user));
+        self::assertNull($handler->create($user, null));
     }
 }

--- a/tests/Handler/AliasHandlerTest.php
+++ b/tests/Handler/AliasHandlerTest.php
@@ -15,7 +15,7 @@ class AliasHandlerTest extends TestCase
     private function createHandler(array $list)
     {
         $repository = $this->getMockBuilder(AliasRepository::class)->disableOriginalConstructor()->getMock();
-        $repository->expects($this->any())->method('findByUser')->willReturn($list);
+        $repository->expects($this->any())->method('findRandomByUser')->willReturn($list);
 
         $manager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
         $manager->expects($this->any())->method('getRepository')->willReturn($repository);
@@ -39,18 +39,18 @@ class AliasHandlerTest extends TestCase
         $handler = $this->createHandler([]);
         $user = new User();
 
-        self::assertInstanceOf(Alias::class, $handler->create($user, null));
+        self::assertInstanceOf(Alias::class, $handler->createRandom($user));
     }
 
     public function testCreateLimit()
     {
         $list = [];
-        for ($i = 0; $i <= AliasHandler::ALIAS_LIMIT; ++$i) {
+        for ($i = 0; $i <= AliasHandler::ALIAS_LIMIT_RANDOM; ++$i) {
             $list[] = 'dummy';
         }
         $handler = $this->createHandler($list);
         $user = new User();
 
-        self::assertNull($handler->create($user, null));
+        self::assertNull($handler->createRandom($user));
     }
 }


### PR DESCRIPTION
Right now, I expose the validator error message. On the good side, it shows why an alias couldn't be created. On the bad side:

1) Allows to see if an email address already exists
2) Error is always shown in English

Number 1) is a bigger problem than in registration because users have the possibility to create and delete an infinite amount of aliases. Which makes enumeration easy. Do you have an idea how to handle this?